### PR TITLE
time of last move

### DIFF
--- a/contracts/manifests/dev/abis/base/contracts/mancala_systems_actions_actions.json
+++ b/contracts/manifests/dev/abis/base/contracts/mancala_systems_actions_actions.json
@@ -123,6 +123,10 @@
         "type": "core::integer::u64"
       },
       {
+        "name": "last_move_at",
+        "type": "core::integer::u64"
+      },
+      {
         "name": "time_between_move",
         "type": "core::integer::u64"
       },

--- a/contracts/manifests/dev/abis/base/models/mancala_models_mancala_game_mancala_game.json
+++ b/contracts/manifests/dev/abis/base/models/mancala_models_mancala_game_mancala_game.json
@@ -387,6 +387,10 @@
         "type": "core::integer::u64"
       },
       {
+        "name": "last_move_at",
+        "type": "core::integer::u64"
+      },
+      {
         "name": "time_between_move",
         "type": "core::integer::u64"
       },

--- a/contracts/manifests/dev/base/contracts/mancala_systems_actions_actions.toml
+++ b/contracts/manifests/dev/base/contracts/mancala_systems_actions_actions.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x4543302a703b8c2e2275cfc1e823a2ed423ecc74b5a4c7dd7c9e16f8705d029"
-original_class_hash = "0x4543302a703b8c2e2275cfc1e823a2ed423ecc74b5a4c7dd7c9e16f8705d029"
+class_hash = "0x1bf064aa3b854cd8adc0c228564241127d0929693c9a96f0eac64959317d4f8"
+original_class_hash = "0x1bf064aa3b854cd8adc0c228564241127d0929693c9a96f0eac64959317d4f8"
 base_class_hash = "0x0"
 abi = "manifests/dev/abis/base/contracts/mancala_systems_actions_actions.json"
 reads = []

--- a/contracts/manifests/dev/base/models/mancala_models_mancala_game_mancala_game.toml
+++ b/contracts/manifests/dev/base/models/mancala_models_mancala_game_mancala_game.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0xdb89747801cdcd3bc7df959974c149596121fafcdd3cb8a388d7841f510cb8"
-original_class_hash = "0xdb89747801cdcd3bc7df959974c149596121fafcdd3cb8a388d7841f510cb8"
+class_hash = "0x10008899aafad05b40dd88164d20257c764534260defa637482b7ae44c98c51"
+original_class_hash = "0x10008899aafad05b40dd88164d20257c764534260defa637482b7ae44c98c51"
 abi = "manifests/dev/abis/base/models/mancala_models_mancala_game_mancala_game.json"
 name = "mancala::models::mancala_game::mancala_game"
 
@@ -26,6 +26,11 @@ key = false
 
 [[members]]
 name = "last_move"
+type = "u64"
+key = false
+
+[[members]]
+name = "last_move_at"
 type = "u64"
 key = false
 

--- a/contracts/src/models/mancala_game.cairo
+++ b/contracts/src/models/mancala_game.cairo
@@ -33,6 +33,7 @@ struct MancalaGame {
     player_two: ContractAddress,
     current_player: ContractAddress,
     last_move: u64,
+    last_move_at: u64,
     time_between_move: u64,
     winner: ContractAddress,
     status: GameStatus,
@@ -84,6 +85,7 @@ impl MancalaImpl of MancalaGameTrait {
                 .block_info
                 .unbox()
                 .block_number,
+            last_move_at: 0,
             time_between_move: 100,
             winner: ContractAddressZeroable::zero(),
             current_player: player_one,
@@ -181,6 +183,13 @@ impl MancalaImpl of MancalaGameTrait {
         ref seeds: u8,
         selected_pit: u8
     ) {
+        //set the last move time to the current block time
+        self.last_move_at = get_execution_info_syscall()
+        .unwrap_syscall()
+        .unbox()
+        .block_info
+        .unbox()
+        .block_timestamp;
         // go to next pit
         let mut current_pit = selected_pit + 1;
         let mut last_pit = current_pit;
@@ -393,6 +402,7 @@ impl MancalaImpl of MancalaGameTrait {
                 .block_info
                 .unbox()
                 .block_number,
+            last_move_at: 0,
             time_between_move: 100,
             winner: ContractAddressZeroable::zero(),
             status: GameStatus::Pending,


### PR DESCRIPTION
This PR adds a parameter called ```last_move_at``` to the mancala game models with an initial value of 0, then updates it with the block timestamp each time the game move function is called as the seeds are being distributed.

This PR closes: https://github.com/realm-of-ra/mancala/issues/152