### PR TITLE
Score and Seed UI update

### DIFF
--- a/client/src/components/gameplay/game-board.tsx
+++ b/client/src/components/gameplay/game-board.tsx
@@ -77,44 +77,57 @@ const GameBoard: React.FC<GameBoardProps> = ({
   return (
     <div className="w-full h-[400px] flex flex-col items-center justify-center mt-24">
       <div className="w-[1170px] h-[400px] flex flex-row items-center justify-between space-x-5 relative bg-[url('./assets/game_board.png')] bg-contain bg-center bg-no-repeat">
-        <div className="w-fit h-[240px] flex items-center mb-5">
+        <div className="w-fit h-[220px] mt-14 relative">
           {/* Player 1 pot */}
           <div
-            className={clsx(
-              opposition_length > 20 ? "ml-[146px]" : "ml-[156px]",
-              "flex flex-row justify-center items-center px-2.5",
-            )}
+            className={
+              "w-fit max-w-14 h-fit max-h-40 flex flex-col flex-wrap -mt-2.5"
+            }
+            style={{
+              marginLeft:
+                opponent_pot_seed_count <= 10
+                  ? "185px"
+                  : opponent_pot_seed_count >= 21 &&
+                      opponent_pot_seed_count < 31
+                    ? "155px"
+                    : opponent_pot_seed_count >= 31 &&
+                        opponent_pot_seed_count < 41
+                      ? "160px"
+                      : opponent_pot_seed_count >= 41
+                        ? "160px"
+                        : "170px",
+            }}
           >
-            <div
-              className={clsx(
-                opposition_length > 10 && "grid grid-cols-2",
-                opposition_length > 20 && "grid grid-cols-3",
-                opposition_length > 30 && "grid grid-cols-5",
-              )}
-            >
-              {// involved && data?.mancalaSeedModels.edges.filter((item: any) => item?.node.player === game_players?.mancalaPlayerModels.edges[opponent_position]?.node.address)
-              data?.mancalaSeedModels.edges
-                .filter(
-                  (item: any) =>
-                    item?.node.player ===
-                    game_players?.mancalaPlayerModels.edges[opponent_position]
-                      ?.node.address,
-                )
-                .filter((item: any) => item?.node.pit_number === 7)
-                .slice(0, opponent_pot_seed_count)
-                .map((seed: any, index: number) => (
+            {
+              // involved && data?.mancalaSeedModels.edges.filter((item: any) => item?.node.player === game_players?.mancalaPlayerModels.edges[opponent_position]?.node.address)
+              // data?.mancalaSeedModels.edges
+              //   .filter(
+              //     (item: any) =>
+              //       item?.node.player ===
+              //       game_players?.mancalaPlayerModels.edges[opponent_position]
+              //         ?.node.address,
+              //   )
+              //   .filter((item: any) => item?.node.pit_number === 7)
+              //   .slice(0, opponent_pot_seed_count)
+              Array.from({ length: opponent_pot_seed_count }).map(
+                (seed: any, index: number) => (
                   <div
                     key={index}
                     style={{
                       width: opposition_length > 30 ? "8px" : "auto",
                     }}
                   >
-                    <Seed color={seed.node.color} />
+                    <Seed
+                      color={seed?.node.color || "Blue"}
+                      length={opponent_pot_seed_count}
+                      type="opponent"
+                    />
                   </div>
-                ))}
-            </div>
+                ),
+              )
+            }
           </div>
-          <div className="absolute inset-y-0 self-center left-32 ml-1.5 mb-6">
+          <div className="absolute inset-y-0 self-center left-32 ml-1.5 mb-20">
             <p className="text-white text-center">
               {
                 data?.mancalaSeedModels.edges
@@ -300,16 +313,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
                       : "170px",
             }}
           >
-            {// involved && data?.mancalaSeedModels.edges
-            // .filter(
-            //   (item: any) =>
-            //     item?.node.player ===
-            //     game_players?.mancalaPlayerModels.edges[player_position]?.node
-            //       .address,
-            // )
-            // .filter((item: any) => item?.node.pit_number === 7)
-            // .slice(0, player_pot_seed_count))
-            data?.mancalaSeedModels.edges
+            {data?.mancalaSeedModels.edges
               .filter(
                 (item: any) =>
                   item?.node.player ===
@@ -323,6 +327,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
                   <Seed
                     color={seed?.node.color || "Blue"}
                     length={player_pot_seed_count}
+                    type="player"
                   />
                 </div>
               ))}

--- a/client/src/components/gameplay/game-board.tsx
+++ b/client/src/components/gameplay/game-board.tsx
@@ -98,34 +98,30 @@ const GameBoard: React.FC<GameBoardProps> = ({
                         : "170px",
             }}
           >
-            {
-              // involved && data?.mancalaSeedModels.edges.filter((item: any) => item?.node.player === game_players?.mancalaPlayerModels.edges[opponent_position]?.node.address)
-              // data?.mancalaSeedModels.edges
-              //   .filter(
-              //     (item: any) =>
-              //       item?.node.player ===
-              //       game_players?.mancalaPlayerModels.edges[opponent_position]
-              //         ?.node.address,
-              //   )
-              //   .filter((item: any) => item?.node.pit_number === 7)
-              //   .slice(0, opponent_pot_seed_count)
-              Array.from({ length: opponent_pot_seed_count }).map(
-                (seed: any, index: number) => (
-                  <div
-                    key={index}
-                    style={{
-                      width: opposition_length > 30 ? "8px" : "auto",
-                    }}
-                  >
-                    <Seed
-                      color={seed?.node.color || "Blue"}
-                      length={opponent_pot_seed_count}
-                      type="opponent"
-                    />
-                  </div>
-                ),
+            {// involved && data?.mancalaSeedModels.edges.filter((item: any) => item?.node.player === game_players?.mancalaPlayerModels.edges[opponent_position]?.node.address)
+            data?.mancalaSeedModels.edges
+              .filter(
+                (item: any) =>
+                  item?.node.player ===
+                  game_players?.mancalaPlayerModels.edges[opponent_position]
+                    ?.node.address,
               )
-            }
+              .filter((item: any) => item?.node.pit_number === 7)
+              .slice(0, opponent_pot_seed_count)
+              .map((seed: any, index: number) => (
+                <div
+                  key={index}
+                  style={{
+                    width: opposition_length > 30 ? "8px" : "auto",
+                  }}
+                >
+                  <Seed
+                    color={seed?.node.color || "Blue"}
+                    length={opponent_pot_seed_count}
+                    type="opponent"
+                  />
+                </div>
+              ))}
           </div>
           <div className="absolute inset-y-0 self-center left-32 ml-1.5 mb-20">
             <p className="text-white text-center">

--- a/client/src/components/gameplay/game-board.tsx
+++ b/client/src/components/gameplay/game-board.tsx
@@ -29,7 +29,9 @@ const GameBoard: React.FC<GameBoardProps> = ({
     variables: { gameId: gameId },
   });
   startPolling(1000);
-  const involved = game_players?.mancalaPlayerModels.edges.some((item: any) => item?.node.address === account.address);
+  const involved = game_players?.mancalaPlayerModels.edges.some(
+    (item: any) => item?.node.address === account.address,
+  );
   const player_position = involved
     ? game_players?.mancalaPlayerModels.edges.findIndex(
         (item: any) => item?.node.address === account.address,
@@ -71,6 +73,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
       )
       .filter((item: any) => item?.node.pit_number === 7)[0]?.node
       ?.seed_count || 0;
+
   return (
     <div className="w-full h-[400px] flex flex-col items-center justify-center mt-24">
       <div className="w-[1170px] h-[400px] flex flex-row items-center justify-between space-x-5 relative bg-[url('./assets/game_board.png')] bg-contain bg-center bg-no-repeat">
@@ -283,50 +286,46 @@ const GameBoard: React.FC<GameBoardProps> = ({
         <div className="w-fit h-[220px] mt-14 relative">
           {/* Player 2 pot */}
           <div
-            className={clsx(
-              player_length > 10 && "mr-[170px]",
-              player_length > 20 && "mr-[160px]",
-              player_length > 30 && "mr-[170px]",
-              player_length > 44 && "-mt-4",
-              "mr-[185px] 2xl:mr-[165px] 2xl:-mt-2 -mt-1 flex flex-row justify-center items-center h-[75%]",
-            )}
+            className={
+              "w-fit max-w-14 h-fit max-h-40 flex flex-col flex-wrap -mt-2.5"
+            }
+            style={{
+              marginRight:
+                player_pot_seed_count <= 10
+                  ? "185px"
+                  : player_pot_seed_count >= 31 && player_pot_seed_count < 41
+                    ? "160px"
+                    : player_pot_seed_count >= 41
+                      ? "155px"
+                      : "170px",
+            }}
           >
-            <div
-              className={clsx(
-                player_length > 10 && "grid grid-cols-2",
-                player_length > 20 && "grid grid-cols-3",
-                player_length > 30 && "grid grid-cols-4",
-              )}
-            >
-              {// involved && data?.mancalaSeedModels.edges.filter((item: any) => item?.node.player === game_players?.mancalaPlayerModels.edges[player_position]?.node.address)
-              data?.mancalaSeedModels.edges
-                .filter(
-                  (item: any) =>
-                    item?.node.player ===
-                    game_players?.mancalaPlayerModels.edges[player_position]
-                      ?.node.address,
-                )
-                .filter((item: any) => item?.node.pit_number === 7)
-                .slice(0, player_pot_seed_count)
-                .map((seed: any, index: number) => (
-                  <div
-                    key={index}
-                    style={{
-                      width:
-                        player_length > 20
-                          ? "10px"
-                          : player_length > 30
-                            ? "6px"
-                            : "auto",
-                      marginRight: player_length > 30 ? -1.5 : 0,
-                      marginTop: player_length > 30 ? -1.5 : 0,
-                      zIndex: index,
-                    }}
-                  >
-                    <Seed color={seed.node.color} />
-                  </div>
-                ))}
-            </div>
+            {// involved && data?.mancalaSeedModels.edges
+            // .filter(
+            //   (item: any) =>
+            //     item?.node.player ===
+            //     game_players?.mancalaPlayerModels.edges[player_position]?.node
+            //       .address,
+            // )
+            // .filter((item: any) => item?.node.pit_number === 7)
+            // .slice(0, player_pot_seed_count))
+            data?.mancalaSeedModels.edges
+              .filter(
+                (item: any) =>
+                  item?.node.player ===
+                  game_players?.mancalaPlayerModels.edges[player_position]?.node
+                    .address,
+              )
+              .filter((item: any) => item?.node.pit_number === 7)
+              .slice(0, player_pot_seed_count)
+              .map((seed: any, index: number) => (
+                <div key={index}>
+                  <Seed
+                    color={seed?.node.color || "Blue"}
+                    length={player_pot_seed_count}
+                  />
+                </div>
+              ))}
           </div>
           <div className="absolute inset-y-0 self-center right-32 bottom-20 w-7 h-12">
             <p className="text-white text-center h-full flex flex-col items-center justify-center">

--- a/client/src/components/gameplay/game-board.tsx
+++ b/client/src/components/gameplay/game-board.tsx
@@ -74,6 +74,32 @@ const GameBoard: React.FC<GameBoardProps> = ({
       .filter((item: any) => item?.node.pit_number === 7)[0]?.node
       ?.seed_count || 0;
 
+  const getOpponentMarginLeft = () => {
+    if (opponent_pot_seed_count <= 10) {
+      return "185px";
+    } else if (opponent_pot_seed_count >= 21 && opponent_pot_seed_count < 31) {
+      return "155px";
+    } else if (opponent_pot_seed_count >= 31 && opponent_pot_seed_count < 41) {
+      return "160px";
+    } else if (opponent_pot_seed_count >= 41) {
+      return "160px";
+    } else {
+      return "170px";
+    }
+  };
+
+  const getPlayerMarginRight = () => {
+    if (player_pot_seed_count <= 10) {
+      return "185px";
+    } else if (player_pot_seed_count >= 31 && player_pot_seed_count < 41) {
+      return "160px";
+    } else if (player_pot_seed_count >= 41) {
+      return "155px";
+    } else {
+      return "170px";
+    }
+  };
+
   return (
     <div className="w-full h-[400px] flex flex-col items-center justify-center mt-24">
       <div className="w-[1170px] h-[400px] flex flex-row items-center justify-between space-x-5 relative bg-[url('./assets/game_board.png')] bg-contain bg-center bg-no-repeat">
@@ -84,18 +110,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
               "w-fit max-w-14 h-fit max-h-40 flex flex-col flex-wrap -mt-2.5"
             }
             style={{
-              marginLeft:
-                opponent_pot_seed_count <= 10
-                  ? "185px"
-                  : opponent_pot_seed_count >= 21 &&
-                      opponent_pot_seed_count < 31
-                    ? "155px"
-                    : opponent_pot_seed_count >= 31 &&
-                        opponent_pot_seed_count < 41
-                      ? "160px"
-                      : opponent_pot_seed_count >= 41
-                        ? "160px"
-                        : "170px",
+              marginLeft: getOpponentMarginLeft(),
             }}
           >
             {// involved && data?.mancalaSeedModels.edges.filter((item: any) => item?.node.player === game_players?.mancalaPlayerModels.edges[opponent_position]?.node.address)
@@ -299,14 +314,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
               "w-fit max-w-14 h-fit max-h-40 flex flex-col flex-wrap -mt-2.5"
             }
             style={{
-              marginRight:
-                player_pot_seed_count <= 10
-                  ? "185px"
-                  : player_pot_seed_count >= 31 && player_pot_seed_count < 41
-                    ? "160px"
-                    : player_pot_seed_count >= 41
-                      ? "155px"
-                      : "170px",
+              marginRight: getPlayerMarginRight(),
             }}
           >
             {data?.mancalaSeedModels.edges

--- a/client/src/components/seed.tsx
+++ b/client/src/components/seed.tsx
@@ -3,9 +3,11 @@ import clsx from "clsx";
 export default function Seed({
   color,
   length = 0,
+  type,
 }: {
   color?: string;
   length: number;
+  type: "player" | "opponent";
 }) {
   return (
     <div
@@ -16,7 +18,14 @@ export default function Seed({
         "w-[16px] h-[16px] bg-center bg-cover bg-no-repeat",
       )}
       style={{
-        marginLeft: length >= 21 ? "-8px" : 0,
+        marginLeft:
+          length >= 21 && type === "player"
+            ? "-8px"
+            : length > 30 && length <= 40 && type === "opponent"
+              ? "-5px"
+              : length > 40 && type === "opponent"
+                ? "-7px"
+                : "0px",
       }}
     />
   );

--- a/client/src/components/seed.tsx
+++ b/client/src/components/seed.tsx
@@ -1,7 +1,23 @@
 import clsx from "clsx";
 
-export default function Seed({ color }: { color?: string }) {
-    return (
-        <div className={clsx(color === "Green" ? "bg-[url('./assets/green-seed.png')]" : "bg-[url('./assets/purple-seed.png')]", 'w-[16px] h-[16px] bg-center bg-cover bg-no-repeat')} />
-    )
+export default function Seed({
+  color,
+  length = 0,
+}: {
+  color?: string;
+  length: number;
+}) {
+  return (
+    <div
+      className={clsx(
+        color === "Green"
+          ? "bg-[url('./assets/green-seed.png')]"
+          : "bg-[url('./assets/purple-seed.png')]",
+        "w-[16px] h-[16px] bg-center bg-cover bg-no-repeat",
+      )}
+      style={{
+        marginLeft: length >= 21 ? "-8px" : 0,
+      }}
+    />
+  );
 }

--- a/client/src/components/seed.tsx
+++ b/client/src/components/seed.tsx
@@ -9,6 +9,20 @@ export default function Seed({
   length?: number;
   type?: "player" | "opponent";
 }) {
+  const getMarginLeft = (
+    length: number | 0,
+    type: "player" | "opponent" | undefined,
+  ) => {
+    if (length >= 21 && type === "player") {
+      return "-8px";
+    } else if (length > 30 && length <= 40 && type === "opponent") {
+      return "-5px";
+    } else if (length > 40 && type === "opponent") {
+      return "-7px";
+    } else {
+      return "0px";
+    }
+  };
   return (
     <div
       className={clsx(
@@ -18,14 +32,7 @@ export default function Seed({
         "w-[16px] h-[16px] bg-center bg-cover bg-no-repeat",
       )}
       style={{
-        marginLeft:
-          length >= 21 && type === "player"
-            ? "-8px"
-            : length > 30 && length <= 40 && type === "opponent"
-              ? "-5px"
-              : length > 40 && type === "opponent"
-                ? "-7px"
-                : "0px",
+        marginLeft: getMarginLeft(length, type),
       }}
     />
   );

--- a/client/src/components/seed.tsx
+++ b/client/src/components/seed.tsx
@@ -6,8 +6,8 @@ export default function Seed({
   type,
 }: {
   color?: string;
-  length: number;
-  type: "player" | "opponent";
+  length?: number;
+  type?: "player" | "opponent";
 }) {
   return (
     <div


### PR DESCRIPTION
Fixed the Scores and Seeds Overflow Issue

Before
![image](https://github.com/user-attachments/assets/42e6e0b4-4186-41c4-881f-84619e7c0370)

After
![image](https://github.com/user-attachments/assets/a139d90e-7608-4ea6-b0da-f00078d552bc)

Added seed overlap controls for pots exceeding 30 seeds (will do the same for pits in another PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced game board rendering for improved visual structure and clarity.
	- Expanded `Seed` component functionality with additional props for better configurability.

- **Bug Fixes**
	- Adjusted layout and styling logic for player pots and seeds to ensure consistent appearance.

- **Documentation**
	- Updated interfaces and component signatures for better type specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->